### PR TITLE
Fix incorrect r!rmrole response

### DIFF
--- a/lib/commands/misc/rmrole.js
+++ b/lib/commands/misc/rmrole.js
@@ -37,16 +37,16 @@ module.exports = class RemoveRoleCommand extends Command {
 			return msg.reply("Make sure to enter a role to remove! Ex: r!rmrole Red");
 		}
 
-    const role = msg.guild.roles.find(r => r.name == roleArg);
+		// Prevent removal of required roles (Can be updated in the future if more required roles are ever added)
+    if (roleArg.toLowerCase() === "member") {
+      return msg.reply("You can't remove that role from yourself!");
+    }
+
+		const role = msg.guild.roles.find(r => r.name == roleArg);
 		// Checks that the role provided by the user exists
 		if (!role) {
 			return msg.reply("That role doesn't exist! Remember that role names are case-sensitive. Check which roles you have by clicking/long-pressing on your profile picture by a message or in the member list.");
 		}
-
-    // Prevent removal of required roles (Can be updated in the future if more required roles are ever added)
-    if (roleArg.toLowerCase() === "member") {
-      return msg.reply("You can't remove that role from yourself!");
-    }
 
     if (memberRoles.has(role.id)) {
       msg.member.removeRole(role);


### PR DESCRIPTION
- Fixed `r!rmrole member` claiming that the role doesn't exist rather than telling the user they can't remove that role.
- Problem involved the check for if the user entered "member" as the argument running after the check for whether the role exists.
- Fixes #13 