### PR TITLE
Initiation account age verification

### DIFF
--- a/handlers/handleInitiation.ts
+++ b/handlers/handleInitiation.ts
@@ -3,8 +3,19 @@ import { CommandInteractionConsumer } from "./types";
 import { getGeneralChannel } from "../util/channel";
 import config from "../config";
 
+const ONE_WEEK = 604800000; //miliseconds
+
 export const handleInitiation: CommandInteractionConsumer = async (interaction: CommandInteraction): Promise<void> => {
   const member = (interaction.member! as GuildMember);
+
+  const createdDate = member.user.createdTimestamp;
+  const currentDate = Date.now();
+
+  const accountAge = currentDate - createdDate;
+  
+  if (accountAge < ONE_WEEK) {
+      return interaction.reply({ ephemeral: true, content: 'Account age invalid, your account must be at least 1 week old to become a Member.' });
+  }
   member.roles.add(config.roles.member);
   
   getGeneralChannel(interaction.client)?.send(

--- a/handlers/handleInitiation.ts
+++ b/handlers/handleInitiation.ts
@@ -3,7 +3,7 @@ import { CommandInteractionConsumer } from "./types";
 import { getGeneralChannel } from "../util/channel";
 import config from "../config";
 
-const ONE_WEEK = 604800000; //miliseconds
+const ONE_WEEK = 604800000; //milliseconds
 
 export const handleInitiation: CommandInteractionConsumer = async (interaction: CommandInteraction): Promise<void> => {
   const member = (interaction.member! as GuildMember);


### PR DESCRIPTION
Adds a check to the new member initiation command to verify that an account is at least one week old